### PR TITLE
feat: Implementacion de CRUD para Boards y Tasks

### DIFF
--- a/src/TaskManager.Api/Controllers/BoardsController.cs
+++ b/src/TaskManager.Api/Controllers/BoardsController.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using TaskManager.Infrastructure.Persistence;
+using TaskManager.Domain.Entities;
+using TaskManager.Api.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using TaskManager.Domain.Entities;
+using TaskManager.Infrastructure.Persistence;
+
+namespace TaskManager.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize] //Todo el controller requiere token
+public class BoardsController : ControllerBase
+{
+    private readonly ApplicationDbContext _context;
+
+    public BoardsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    //Obtener tableros del usuario logueado
+    [HttpGet]
+    public IActionResult GetMyBoards()
+    {
+        var userId = GetUserId();
+
+        var boards = _context.Boards
+            .Where(b => b.UserId == userId)
+            .ToList();
+
+        return Ok(boards);
+    }
+
+    //Crear nuevo tablero
+    [HttpPost]
+    public IActionResult CreateBoard([FromBody] CreateBoardRequest request)
+    {
+        var userId = GetUserId();
+
+        var board = new Board
+        {
+            Name = request.Name,
+            UserId = userId
+        };
+
+        _context.Boards.Add(board);
+        _context.SaveChanges();
+
+        return CreatedAtAction(nameof(GetMyBoards), new { id = board.Id }, board);
+    }
+
+    //Helper para obtener UserId del token
+    private Guid GetUserId()
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier);
+
+        if (userIdClaim == null)
+            throw new UnauthorizedAccessException("UserId claim not found");
+
+        return Guid.Parse(userIdClaim.Value);
+    }
+
+    [HttpGet("{id}")]
+    public IActionResult GetBoardById(Guid id)
+    {
+        var userId = GetUserId();
+
+        var board = _context.Boards
+            .Where(b => b.Id == id && b.UserId == userId)
+            .FirstOrDefault();
+
+        if (board == null)
+            return NotFound();
+
+        return Ok(board);
+    }
+
+    [HttpPut("{id}")]
+    public IActionResult UpdateBoard(Guid id, [FromBody] UpdateBoardRequest request)
+    {
+        var userId = GetUserId();
+
+        var board = _context.Boards
+            .FirstOrDefault(b => b.Id == id && b.UserId == userId);
+
+        if (board == null)
+            return NotFound();
+
+        board.Name = request.Name;
+
+        _context.SaveChanges();
+
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public IActionResult DeleteBoard(Guid id)
+    {
+        var userId = GetUserId();
+
+        var board = _context.Boards
+            .FirstOrDefault(b => b.Id == id && b.UserId == userId);
+
+        if (board == null)
+            return NotFound();
+
+        _context.Boards.Remove(board);
+        _context.SaveChanges();
+
+        return NoContent();
+    }
+}

--- a/src/TaskManager.Api/Controllers/TaskController.cs
+++ b/src/TaskManager.Api/Controllers/TaskController.cs
@@ -1,0 +1,149 @@
+namespace TaskManager.Api.Controllers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using TaskManager.Domain.Entities;
+using TaskManager.Infrastructure.Persistence;
+using TaskManager.Api.DTOs;
+
+
+
+[ApiController]
+[Route("api/boards/{boardId}/tasks")]
+[Authorize]
+public class TasksController : ControllerBase
+{
+    private readonly ApplicationDbContext _context;
+
+    public TasksController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    // Obtener todas las tareas de un board
+    [HttpGet]
+    public IActionResult GetTasks(Guid boardId)
+    {
+        var userId = GetUserId();
+
+        var boardExists = _context.Boards
+            .Any(b => b.Id == boardId && b.UserId == userId);
+
+        if (!boardExists)
+            return NotFound("Board not found");
+
+        var tasks = _context.Tasks
+            .Where(t => t.BoardId == boardId)
+            .ToList();
+
+        return Ok(tasks);
+    }
+
+    // Obtener tarea específica
+    [HttpGet("{taskId}")]
+    public IActionResult GetTask(Guid boardId, Guid taskId)
+    {
+        var userId = GetUserId();
+
+        var task = _context.Tasks
+            .Where(t => t.Id == taskId && t.BoardId == boardId)
+            .Join(_context.Boards,
+                  t => t.BoardId,
+                  b => b.Id,
+                  (t, b) => new { Task = t, Board = b })
+            .FirstOrDefault(x => x.Board.UserId == userId);
+
+        if (task == null)
+            return NotFound();
+
+        return Ok(task.Task);
+    }
+
+    // Crear tarea
+    [HttpPost]
+    public IActionResult CreateTask(Guid boardId, [FromBody] CreateTaskRequest request)
+    {
+        var userId = GetUserId();
+
+        var board = _context.Boards
+            .FirstOrDefault(b => b.Id == boardId && b.UserId == userId);
+
+        if (board == null)
+            return NotFound("Board not found");
+
+        var task = new TaskItem
+        {
+            Title = request.Title,
+            Description = request.Description,
+            Status = TaskStatus.Pending,
+            BoardId = boardId
+        };
+
+        _context.Tasks.Add(task);
+        _context.SaveChanges();
+
+        return CreatedAtAction(nameof(GetTask),
+            new { boardId = boardId, taskId = task.Id },
+            task);
+    }
+
+    // Actualizar tarea
+    [HttpPut("{taskId}")]
+    public IActionResult UpdateTask(Guid boardId, Guid taskId, [FromBody] UpdateTaskRequest request)
+    {
+        var userId = GetUserId();
+
+        var task = _context.Tasks
+            .Where(t => t.Id == taskId && t.BoardId == boardId)
+            .Join(_context.Boards,
+                  t => t.BoardId,
+                  b => b.Id,
+                  (t, b) => new { Task = t, Board = b })
+            .FirstOrDefault(x => x.Board.UserId == userId);
+
+        if (task == null)
+            return NotFound();
+
+        task.Task.Title = request.Title;
+        task.Task.Description = request.Description;
+        task.Task.Status = request.Status;
+
+        _context.SaveChanges();
+
+        return NoContent();
+    }
+
+    // Eliminar tarea
+    [HttpDelete("{taskId}")]
+    public IActionResult DeleteTask(Guid boardId, Guid taskId)
+    {
+        var userId = GetUserId();
+
+        var task = _context.Tasks
+            .Where(t => t.Id == taskId && t.BoardId == boardId)
+            .Join(_context.Boards,
+                  t => t.BoardId,
+                  b => b.Id,
+                  (t, b) => new { Task = t, Board = b })
+            .FirstOrDefault(x => x.Board.UserId == userId);
+
+        if (task == null)
+            return NotFound();
+
+        _context.Tasks.Remove(task.Task);
+        _context.SaveChanges();
+
+        return NoContent();
+    }
+
+    //Helper para obtener UserId desde JWT
+    private Guid GetUserId()
+    {
+        var claim = User.FindFirst(ClaimTypes.NameIdentifier);
+
+        if (claim == null)
+            throw new UnauthorizedAccessException("UserId claim not found");
+
+        return Guid.Parse(claim.Value);
+    }
+}

--- a/src/TaskManager.Api/DTOs/CreateBoardRequest.cs
+++ b/src/TaskManager.Api/DTOs/CreateBoardRequest.cs
@@ -1,0 +1,6 @@
+namespace TaskManager.Api.DTOs;
+
+public class CreateBoardRequest
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/TaskManager.Api/DTOs/CreateTaskRequest.cs
+++ b/src/TaskManager.Api/DTOs/CreateTaskRequest.cs
@@ -1,0 +1,9 @@
+using TaskManager.Domain.Entities;
+
+namespace TaskManager.Api.DTOs;
+
+public class CreateTaskRequest
+{
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+}

--- a/src/TaskManager.Api/DTOs/UpdateBoardRequest.cs
+++ b/src/TaskManager.Api/DTOs/UpdateBoardRequest.cs
@@ -1,0 +1,6 @@
+namespace TaskManager.Api.DTOs;
+
+public class UpdateBoardRequest
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/TaskManager.Api/DTOs/UpdateTaskRequest.cs
+++ b/src/TaskManager.Api/DTOs/UpdateTaskRequest.cs
@@ -1,0 +1,9 @@
+namespace TaskManager.Api.DTOs;
+using TaskManager.Domain.Entities;
+
+public class UpdateTaskRequest
+{
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public TaskStatus Status { get; set; }
+}

--- a/src/TaskManager.Api/Program.cs
+++ b/src/TaskManager.Api/Program.cs
@@ -38,7 +38,12 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddAuthorization();
 
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.ReferenceHandler =
+            System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;
+});
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
     {

--- a/src/TaskManager.Domain/Entities/Board.cs
+++ b/src/TaskManager.Domain/Entities/Board.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace TaskManager.Domain.Entities;
+
+public class Board
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string Name { get; set; } = string.Empty;
+
+    public Guid UserId { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation property
+    public ICollection<TaskItem> Tasks { get; set; } = new List<TaskItem>();
+}

--- a/src/TaskManager.Domain/Entities/TaskItem.cs
+++ b/src/TaskManager.Domain/Entities/TaskItem.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace TaskManager.Domain.Entities;
+
+public class TaskItem
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string Title { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public TaskStatus Status { get; set; } = TaskStatus.Pending;
+
+    public Guid BoardId { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation property
+    public Board? Board { get; set; }
+}

--- a/src/TaskManager.Domain/Entities/TaskStatus.cs
+++ b/src/TaskManager.Domain/Entities/TaskStatus.cs
@@ -1,0 +1,8 @@
+namespace TaskManager.Domain.Entities;
+
+public enum TaskStatus
+{
+    Pending = 0,
+    InProgress = 1,
+    Done = 2
+}

--- a/src/TaskManager.Infrastructure/Migrations/20260302194918_AddBoardsAndTasks.Designer.cs
+++ b/src/TaskManager.Infrastructure/Migrations/20260302194918_AddBoardsAndTasks.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TaskManager.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using TaskManager.Infrastructure.Persistence;
 namespace TaskManager.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260302194918_AddBoardsAndTasks")]
+    partial class AddBoardsAndTasks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TaskManager.Infrastructure/Migrations/20260302194918_AddBoardsAndTasks.cs
+++ b/src/TaskManager.Infrastructure/Migrations/20260302194918_AddBoardsAndTasks.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TaskManager.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBoardsAndTasks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Boards",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Boards", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Tasks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    BoardId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tasks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Tasks_Boards_BoardId",
+                        column: x => x.BoardId,
+                        principalTable: "Boards",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tasks_BoardId",
+                table: "Tasks",
+                column: "BoardId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Tasks");
+
+            migrationBuilder.DropTable(
+                name: "Boards");
+        }
+    }
+}

--- a/src/TaskManager.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/TaskManager.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,10 +1,13 @@
 using Microsoft.EntityFrameworkCore;
 using TaskManager.Domain.Entities;
+using TaskManager.Domain.Entities;
 
 namespace TaskManager.Infrastructure.Persistence;
 
 public class ApplicationDbContext : DbContext
 {
+    public DbSet<Board> Boards { get; set; }
+    public DbSet<TaskItem> Tasks { get; set; }
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
     {


### PR DESCRIPTION
## Descripción

Se implementa el CRUD completo para las entidades Boards y Tasks, integrando la lógica con Entity Framework Core y respetando la estructura de Clean Architecture.

### Cambios realizados

- Creación de entidades Board y TaskItem
- Creación del enum TaskStatus
- Configuración de relaciones entre Boards y Tasks
- Generación de migración AddBoardsAndTasks
- Implementación de BoardsController con endpoints CRUD
- Implementación de TasksController con endpoints CRUD anidados por Board
- Protección de endpoints con autenticación JWT
- Validación de acceso por usuario autenticado
- Pruebas de endpoints mediante Swagger

## Impacto

La aplicación ahora permite gestionar tableros y tareas asociadas, con aislamiento por usuario autenticado y persistencia en base de datos PostgreSQL.

## Issue relacionado

Closes #3